### PR TITLE
Expand capabilities request for typescript diagnostics

### DIFF
--- a/src/lspClient.ts
+++ b/src/lspClient.ts
@@ -317,6 +317,16 @@ export class LSPClient {
             },
             codeAction: {
               dynamicRegistration: true
+            },
+            diagnostic: {
+              dynamicRegistration: false
+            },
+            publishDiagnostics: {
+              relatedInformation: true,
+              versionSupport: false,
+              tagSupport: {},
+              codeDescriptionSupport: true,
+              dataSupport: true
             }
           }
         }


### PR DESCRIPTION
Prior to this commit we only passed a small set of capabilites. Typescript language server needs some more in order to publish diagnostics.

This commit adds extra capabilities during initialization and now I see diagnostic messages published to lsp-mcp.